### PR TITLE
Disable plugins by default

### DIFF
--- a/lib/plugins/EPrints/Plugin/Screen/EPrint/HefceOA.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/EPrint/HefceOA.pm
@@ -17,7 +17,9 @@ sub new
 			position => 3000,
 		},
 	];
-
+	#avoid issues with multiple archives under <v3.3.13
+	$self->{disable} = 1;
+	
 	return $self;
 }
 

--- a/lib/plugins/EPrints/Plugin/Screen/Report/REF_CC.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/REF_CC.pm
@@ -15,6 +15,7 @@ sub new
 	$self->{custom_order} = '-title/creators_name';
 	$self->{appears} = [];
 	$self->{report} = 'ref_cc';
+	$self->{disable} = 1;
 
 	return $self;
 }


### PR DESCRIPTION
Fixes #1 

This https://github.com/eprints/eprints/issues/223 was only merged in version 3.3.13.
On EPrints versions earlier than that, this package (and many other Bazaar packages) break multiple-archive configs.

Notes:
Screen::EPMC is enabled by default in perl_lib - and anything inheriting from it will also be enabled by default.
Screen::Report::REF_CC is now disabled by default - sub classes of this should also inherit (and therefore be disabled by default)?
