### PR TITLE
Fix to exceptions display in report.

### DIFF
--- a/lib/plugins/EPrints/Plugin/Screen/Report/REF_CC/EX_2015.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report/REF_CC/EX_2015.pm
@@ -39,10 +39,10 @@ sub validate_dataobj
 	{
 		if( $eprint->is_set( $_ ) )
 		{
-			push @problems, $repo->html_phrase( "Plugin/Screen/EPrint/HefceOA:render_exception", 
-				title => $repo->html_phrase( "eprint_fieldname_$_" ),
-				exception => $eprint->render_value( $_ ),
-				explanation => $eprint->render_value( "$_\_txt" ),
+			push @problems, $repo->phrase( "Plugin/Screen/EPrint/HefceOA:render_exception", 
+				title => "<b>" . $repo->phrase( "eprint_fieldname_$_" ) . "</b>",
+				exception => EPrints::Utils::tree_to_utf8( $eprint->render_value( $_ ) ),
+				explanation => EPrints::Utils::tree_to_utf8( $eprint->render_value( "$_\_txt" ) ),
 			);
 		}
 	}


### PR DESCRIPTION
Hello,

I came across an issue with the exceptions not being displayed correctly in the "Exceptions Used" report. Instead of the title and exception rendering correctly as per the "REF CC" -> "Exceptions" tab on the eprint details screen, it was instead appearing like so "XML::LibXML::DocumentFragment=SCALAR(0xe8bb6a8)" (for example).

It would seem the phrase that was being added to the problems array needed its HTML elements removing - I'm not entirely sure why, but it appears to have fixed the problem!
