### PR TITLE
Automatic population of embargo length.

### DIFF
--- a/lib/cfg.d/hefce_oa_integration.pl
+++ b/lib/cfg.d/hefce_oa_integration.pl
@@ -90,6 +90,10 @@ $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 			$eprint->set_value( 'hoa_emb_len', int($len->months) );
 		}
 	}
+	elsif( !$doc->exists_and_set( 'date_embargo' ) )
+	{
+		$eprint->set_value( 'hoa_emb_len', undef );
+	}
 }, priority => 100 ); # needs to be called before the compliance flag is set
 
 

--- a/lib/cfg.d/hefce_oa_integration.pl
+++ b/lib/cfg.d/hefce_oa_integration.pl
@@ -132,6 +132,10 @@ $c->{hefce_oa}->{select_document} = sub {
 		{
 			return $_;
 		}
+		elsif( !$result )
+		{
+			$result = $_; #no embargo date and it isn't public
+		}
 	}
 	return $result;
 };

--- a/lib/cfg.d/hefce_oa_integration.pl
+++ b/lib/cfg.d/hefce_oa_integration.pl
@@ -120,7 +120,7 @@ $c->{hefce_oa}->{select_document} = sub {
 
         @possible_docs = sort {
 		# public is best. NB Can't use $doc->is_public here, is it checks EPrint is in 'archive' too.
-		($b->exists_and_set( "security " ) && $b->value( "security" ) eq "public" ) <=> ($a->exists_and_set( "security" ) && $a->value( "security" ) eq "public" ) or
+		($b->is_set( "security " ) && $b->value( "security" ) eq "public" ) <=> ($a->is_set( "security" ) && $a->value( "security" ) eq "public" ) or
 		# something not public, but with an embargo set is better than a permanently embargoed item
 		# again, with $a and $b swapped as is_set returns 1 or 0.
 		$b->is_set( "date_embargo" ) <=> $a->is_set( "date_embargo" )  or

--- a/lib/cfg.d/hefce_oa_integration.pl
+++ b/lib/cfg.d/hefce_oa_integration.pl
@@ -119,8 +119,8 @@ $c->{hefce_oa}->{select_document} = sub {
         );
 
         @possible_docs = sort {
-		# is_public=1 is better than is_public=0 - but <=> is numeric comparison - so swap $a and $b
-		$b->is_public <=> $a->is_public or
+		# public is best. NB Can't use $doc->is_public here, is it checks EPrint is in 'archive' too.
+		($b->exists_and_set( "security " ) && $b->value( "security" ) eq "public" ) <=> ($a->exists_and_set( "security " ) && $a->value( "security" ) eq "public" ) or
 		# something not public, but with an embargo set is better than a permanently embargoed item
 		# again, with $a and $b swapped as is_set returns 1 or 0.
 		$b->is_set( "date_embargo" ) <=> $a->is_set( "date_embargo" )  or

--- a/lib/cfg.d/hefce_oa_integration.pl
+++ b/lib/cfg.d/hefce_oa_integration.pl
@@ -120,7 +120,7 @@ $c->{hefce_oa}->{select_document} = sub {
 
         @possible_docs = sort {
 		# public is best. NB Can't use $doc->is_public here, is it checks EPrint is in 'archive' too.
-		($b->exists_and_set( "security " ) && $b->value( "security" ) eq "public" ) <=> ($a->exists_and_set( "security " ) && $a->value( "security" ) eq "public" ) or
+		($b->exists_and_set( "security " ) && $b->value( "security" ) eq "public" ) <=> ($a->exists_and_set( "security" ) && $a->value( "security" ) eq "public" ) or
 		# something not public, but with an embargo set is better than a permanently embargoed item
 		# again, with $a and $b swapped as is_set returns 1 or 0.
 		$b->is_set( "date_embargo" ) <=> $a->is_set( "date_embargo" )  or
@@ -133,6 +133,20 @@ $c->{hefce_oa}->{select_document} = sub {
                 $pref{$a->value( "content" )} <=> $pref{$b->value( "content" )} 
 		
         } @possible_docs;
+
+my @test_docs = sort {
+	$a->is_set( "security" ) <=> $b->is_set( "security" )
+} @possible_docs; 
+#for( @possible_docs ){
+#	print STDERR $_->is_set( "content" );
+#	print STDERR $_->is_set( "pos" );
+#	print STDERR $_->is_set( "format" );
+#	print STDERR $_->is_set( "formatdesc" );
+#	print STDERR $_->is_set( "license" );
+#	print STDERR $_->is_set( "main" );
+#	print STDERR $_->is_set( "relation" );
+#	print STDERR $_->is_set( "security" );
+#}
 
 	return $possible_docs[0];
 };

--- a/lib/cfg.d/hefce_oa_integration.pl
+++ b/lib/cfg.d/hefce_oa_integration.pl
@@ -120,7 +120,7 @@ $c->{hefce_oa}->{select_document} = sub {
 
         @possible_docs = sort {
 		# public is best. NB Can't use $doc->is_public here, is it checks EPrint is in 'archive' too.
-		($b->is_set( "security " ) && $b->value( "security" ) eq "public" ) <=> ($a->is_set( "security" ) && $a->value( "security" ) eq "public" ) or
+		($b->is_set( "security" ) && $b->value( "security" ) eq "public" ) <=> ($a->is_set( "security" ) && $a->value( "security" ) eq "public" ) or
 		# something not public, but with an embargo set is better than a permanently embargoed item
 		# again, with $a and $b swapped as is_set returns 1 or 0.
 		$b->is_set( "date_embargo" ) <=> $a->is_set( "date_embargo" )  or

--- a/lib/cfg.d/hefce_oa_integration.pl
+++ b/lib/cfg.d/hefce_oa_integration.pl
@@ -134,20 +134,6 @@ $c->{hefce_oa}->{select_document} = sub {
 		
         } @possible_docs;
 
-my @test_docs = sort {
-	$a->is_set( "security" ) <=> $b->is_set( "security" )
-} @possible_docs; 
-#for( @possible_docs ){
-#	print STDERR $_->is_set( "content" );
-#	print STDERR $_->is_set( "pos" );
-#	print STDERR $_->is_set( "format" );
-#	print STDERR $_->is_set( "formatdesc" );
-#	print STDERR $_->is_set( "license" );
-#	print STDERR $_->is_set( "main" );
-#	print STDERR $_->is_set( "relation" );
-#	print STDERR $_->is_set( "security" );
-#}
-
 	return $possible_docs[0];
 };
 

--- a/lib/cfg.d/hefce_oa_integration.pl
+++ b/lib/cfg.d/hefce_oa_integration.pl
@@ -1,4 +1,4 @@
-# attempt to set hoa_date_acc and hoa_date_pub from various sources
+# attempt to set hoa_date_acc and hoa_date_pub from various sources as well as hoa_emb_len
 $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 {
 	my( %args ) = @_; 
@@ -61,16 +61,67 @@ $c->add_dataset_trigger( 'eprint', EPrints::Const::EP_TRIGGER_BEFORE_COMMIT, sub
 		$pub_date = $eprint->value( 'rioxx2_publication_date' );
 	}
 
+	#initialise pub_time for later use when calculating hoa_emb_len
+	my $pub_time;
+
 	# now set the values - date of acceptance
 	$eprint->set_value( 'hoa_date_acc', $acc_date ) if defined $acc_date;
 	#prefer a published_online date
 	if( defined $pub_online_date )
 	{
 		$eprint->set_value( 'hoa_date_pub', $pub_online_date );
+		$pub_time = Time::Piece->strptime( $pub_online_date, "%Y-%m-%d" );
 	}
 	elsif( defined $pub_date ) #but use a published date if that's not available.
 	{
 		$eprint->set_value( 'hoa_date_pub', $pub_date );
+		$pub_time = Time::Piece->strptime( $pub_date, "%Y-%m-%d" );
 	}
-    
+
+	#now try and set hoa_emb_len
+	my $doc = $repo->call( [qw( hefce_oa select_document )], $eprint );
+	if( $doc && $doc->exists_and_set( 'date_embargo' ) && $pub_time )
+	{
+		#get embargo date
+		my $emb_time = Time::Piece->strptime( $doc->value( 'date_embargo' ), "%Y-%m-%d" );
+		if( $emb_time > $pub_time ) #embargo date must come after publication date
+		{
+			#get embargo length
+			my $len = $emb_time-$pub_time;
+			$eprint->set_value( 'hoa_emb_len', int($len->months) );
+		}
+	}
 }, priority => 100 ); # needs to be called before the compliance flag is set
+
+#copied from RIOXX2 plugin
+$c->{hefce_oa}->{select_document} = sub {
+        my( $eprint ) = @_;
+
+        my @docs = $eprint->get_all_documents;
+
+        # simple cases
+        return unless scalar @docs;
+        return $docs[0] if scalar @docs == 1;
+
+        # prefer published, accepted and submitted versions over anything else
+        my %pref = (
+                published => 3,
+                accepted => 2,
+                submitted => 1,
+        );
+
+        my @ordered = sort {
+                ($pref{$b->value( "content" )||""}||0) <=> ($pref{$a->value( "content" )||""}||0)
+        } @docs;
+
+        return $ordered[0] if $ordered[0]->is_set( "content" );
+
+        # prefer text documents
+        for( @docs )
+        {
+                return $_ if $_->value( "format" ) eq "text";
+        }
+
+        return $docs[0];
+};
+


### PR DESCRIPTION
Fix for https://github.com/eprintsug/hefce_oa/issues/23

Will try and use the published online date where possible and then the published date as per HEFCE guidance (although should it actually compare them and use the earliest rather than assume published_online will be the earliest?).
