### PR TITLE
Adjust previous 2017 date to 2018

### DIFF
--- a/lib/cfg.d/hefce_oa_tests.pl
+++ b/lib/cfg.d/hefce_oa_tests.pl
@@ -100,7 +100,7 @@ $c->{hefce_oa}->{run_test_DEP_TIMING} = sub {
 	return 0 unless $eprint->is_set( "hoa_date_fcd" );
 	
 	my $dep = Time::Piece->strptime( $eprint->value( "hoa_date_fcd" ), "%Y-%m-%d" );
-	my $APR17 = Time::Piece->strptime( "2017-04-01", "%Y-%m-%d" );
+	my $APR18 = Time::Piece->strptime( "2018-04-01", "%Y-%m-%d" );
 
 	# checks based on date of acceptance (if set)
 	if( $eprint->is_set( "hoa_date_acc" ) )
@@ -118,8 +118,8 @@ $c->{hefce_oa}->{run_test_DEP_TIMING} = sub {
 		# deposit is within 3  months of acceptance
 		return 1 if $dep <= $acc->add_months(3); 
 
-		#for pre-April '17, base calculation on pub date
-		if( $acc < $APR17 && $eprint->is_set( "hoa_date_pub" ) )
+		#for pre-April '18, base calculation on pub date
+		if( $acc < $APR18 && $eprint->is_set( "hoa_date_pub" ) )
 		{
 			my $pub;
 			if( $repo->can_call( "hefce_oa", "handle_possibly_incomplete_date" ) )
@@ -146,10 +146,10 @@ $c->{hefce_oa}->{run_test_DEP_TIMING} = sub {
 			$pub = Time::Piece->strptime( $eprint->value( "hoa_date_pub" ), "%Y-%m-%d" );
 		}
 		
-		#if published date is before 2017-04-01, acceptance date must be too.
+		#if published date is before 2018-04-01, acceptance date must be too.
 		# NB we may need to introduce a lag here - if it normally takes a month to get something published,
-		# we may need to check for 'APR17 + 1 month'
-		if( $pub < $APR17 )
+		# we may need to check for 'APR18 + 1 month'
+		if( $pub < $APR18 )
 		{
 			return 1 if $dep <= $pub->add_months(3);
 		}


### PR DESCRIPTION
Small change: adjusted date and var name on line 103 ($APR17 --> $APR18) and var references/comments on lines 121, 122, 149, 151 and 152.

This is to accommodate the changes to HEFCE OA policy released Nov 2016. See below for details:

"HEFCE published an update to its OA policy (http://www.hefce.ac.uk/pubs/year/2016/201635/)
As previously known, 01/04/2016 was not envisaged any longer the hard deadline ( to make submitted output OA  within three months of acceptance) , but now there is a para ( page 5, 19  ‘on deposit requirements’) stating 
 
To take account of the need for systems to be developed to support deposit-on-acceptance, during the first two years of the policy (1 April 2016 – 1 April 2018), outputs can be deposited up to three months after the date of publication. This flexibility will be subject to a review of the readiness of systems within the sector in autumn 2017. 
 
Date of publication is defined as first availability online (not the print date)
 
This basically is a relaxation on ‘acceptance’ (but not a let-off) for publications published 01/04/2016 – 01/04/2018. OA still needs to be achieved three months AFTER publication/availablity online."